### PR TITLE
TypeScript - Add overload for `ReadonlyArray`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,7 @@ arrify(undefined);
 declare function arrify(value: null | undefined): [];
 declare function arrify(value: string): [string];
 declare function arrify<ValueType>(value: ValueType[]): ValueType[];
+declare function arrify<ValueType>(value: ReadonlyArray<ValueType>): ReadonlyArray<ValueType>;
 declare function arrify<ValueType>(value: Iterable<ValueType>): ValueType[];
 declare function arrify<ValueType>(value: ValueType): [ValueType];
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,7 @@ arrify(undefined);
 declare function arrify(value: null | undefined): [];
 declare function arrify(value: string): [string];
 declare function arrify<ValueType>(value: ValueType[]): ValueType[];
+// TODO: use 'readonly ValueType[]' in the next major version
 declare function arrify<ValueType>(value: ReadonlyArray<ValueType>): ReadonlyArray<ValueType>;
 declare function arrify<ValueType>(value: Iterable<ValueType>): ValueType[];
 declare function arrify<ValueType>(value: ValueType): [ValueType];

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,7 +26,7 @@ arrify(undefined);
 declare function arrify(value: null | undefined): [];
 declare function arrify(value: string): [string];
 declare function arrify<ValueType>(value: ValueType[]): ValueType[];
-// TODO: use 'readonly ValueType[]' in the next major version
+// TODO: Use 'readonly ValueType[]' in the next major version
 declare function arrify<ValueType>(value: ReadonlyArray<ValueType>): ReadonlyArray<ValueType>;
 declare function arrify<ValueType>(value: Iterable<ValueType>): ValueType[];
 declare function arrify<ValueType>(value: ValueType): [ValueType];

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,4 @@
-import {expectType} from 'tsd';
+import {expectType, expectError} from 'tsd';
 import arrify = require('.');
 
 expectType<[]>(arrify(null));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -12,4 +12,4 @@ expectType<([string | number, string | number])[]>(
 	arrify(new Map<string | number, string | number>([[1, 2], ['a', 'b']]))
 );
 expectType<number[]>(arrify(new Set([1, 2])));
-expectType<ReadonlyArray<number>>(arrify([Number()] as const));
+expectError(arrify(['🦄'] as const).push(''));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -12,3 +12,4 @@ expectType<([string | number, string | number])[]>(
 	arrify(new Map<string | number, string | number>([[1, 2], ['a', 'b']]))
 );
 expectType<number[]>(arrify(new Set([1, 2])));
+expectType<ReadonlyArray<number>>(arrify([Number()] as const));


### PR DESCRIPTION
If passed an array `arrify` returns the same refrence. With the current type declarations this would convert a `ReadonlyArray<T>` to a mutable `Array<T>` because it matches the overload with `Iterable<T>`.
This adds an overload to make sure readonly arrays are not mutated after being passed through arrify.