### PR TITLE
TypeScript - Fix handling of union types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,12 +23,18 @@ arrify(undefined);
 //=> []
 ```
 */
-declare function arrify(value: null | undefined): [];
-declare function arrify(value: string): [string];
-declare function arrify<ValueType>(value: ValueType[]): ValueType[];
-// TODO: Use 'readonly ValueType[]' in the next major version
-declare function arrify<ValueType>(value: ReadonlyArray<ValueType>): ReadonlyArray<ValueType>;
-declare function arrify<ValueType>(value: Iterable<ValueType>): ValueType[];
-declare function arrify<ValueType>(value: ValueType): [ValueType];
+declare function arrify<ValueType>(
+	value: ValueType
+): ValueType extends (null | undefined)
+	? []
+	: ValueType extends string
+	? [string]
+	: ValueType extends (infer T)[]
+	? T[]
+	: ValueType extends ReadonlyArray<infer T> // TODO: Use 'readonly (infer T)[]' in the next major version
+	? ReadonlyArray<T>
+	: ValueType extends Iterable<infer T>
+	? T[]
+	: [ValueType];
 
 export = arrify;

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,10 +29,8 @@ declare function arrify<ValueType>(
 	? []
 	: ValueType extends string
 	? [string]
-	: ValueType extends (infer T)[]
-	? T[]
-	: ValueType extends ReadonlyArray<infer T> // TODO: Use 'readonly (infer T)[]' in the next major version
-	? ReadonlyArray<T>
+	: ValueType extends ReadonlyArray<unknown> // TODO: Use 'readonly unknown[]' in the next major version
+	? ValueType
 	: ValueType extends Iterable<infer T>
 	? T[]
 	: [ValueType];

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -8,8 +8,9 @@ expectType<string[]>(arrify(['🦄']));
 expectType<[boolean]>(arrify(true));
 expectType<[number]>(arrify(1));
 expectType<[{}]>(arrify({}));
-expectType<([string | number, string | number])[]>(
-	arrify(new Map<string | number, string | number>([[1, 2], ['a', 'b']]))
+expectType<[number, string]>(arrify([1, 'foo']));
+expectType<(string | boolean)[]>(
+	arrify(new Set<string | boolean>(['🦄', true]))
 );
 expectType<number[]>(arrify(new Set([1, 2])));
 expectError(arrify(['🦄'] as const).push(''));
@@ -20,6 +21,9 @@ expectType<number[] | string[]>(arrify(Boolean() ? [1, 2] : ['🦄']));
 expectType<number[] | [boolean]>(arrify(Boolean() ? [1, 2] : true));
 expectType<number[] | [number]>(arrify(Boolean() ? [1, 2] : 3));
 expectType<number[] | [{}]>(arrify(Boolean() ? [1, 2] : {}));
+expectType<number[] | [number, string]>(
+	arrify(Boolean() ? [1, 2] : [1, 'foo'])
+);
 expectType<number[] | (string | boolean)[]>(
 	arrify(Boolean() ? [1, 2] : new Set<string | boolean>(['🦄', true]))
 );

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -13,3 +13,16 @@ expectType<([string | number, string | number])[]>(
 );
 expectType<number[]>(arrify(new Set([1, 2])));
 expectError(arrify(['🦄'] as const).push(''));
+expectType<number[] | []>(arrify(Boolean() ? [1, 2] : null));
+expectType<number[] | []>(arrify(Boolean() ? [1, 2] : undefined));
+expectType<number[] | [string]>(arrify(Boolean() ? [1, 2] : '🦄'));
+expectType<number[] | string[]>(arrify(Boolean() ? [1, 2] : ['🦄']));
+expectType<number[] | [boolean]>(arrify(Boolean() ? [1, 2] : true));
+expectType<number[] | [number]>(arrify(Boolean() ? [1, 2] : 3));
+expectType<number[] | [{}]>(arrify(Boolean() ? [1, 2] : {}));
+expectType<number[] | (string | boolean)[]>(
+	arrify(Boolean() ? [1, 2] : new Set<string | boolean>(['🦄', true]))
+);
+expectType<number[] | [boolean] | [string]>(
+	arrify(Boolean() ? [1, 2] : Boolean() ? true : '🦄')
+);


### PR DESCRIPTION
Original patch proposed in #9 by @callmehiphop. This is an extension that handles all possible union type combinations. Thank you!

Fixes #8
Fixes #10